### PR TITLE
Removed gosford scraper as it redirects to an ePathway site.

### DIFF
--- a/lib/icon_scraper/authorities.rb
+++ b/lib/icon_scraper/authorities.rb
@@ -35,11 +35,6 @@ module IconScraper
       url: "http://eplanning.whitsundayrc.qld.gov.au/Pages/XC.Track",
       period: "last28days"
     },
-    gosford: {
-      url: "https://plan.s.centralcoast.nsw.gov.au/Pages/XC.Track",
-      period: "last14days",
-      ssl_verify: false
-    },
     cumberland: {
       url: "https://cumberland-eplanning.t1cloud.com/Pages/XC.Track",
       period: "last14days"


### PR DESCRIPTION
No data has been recieved for Central Coast Council (Gosford). The scraper fails since Gosford now uses ePathway

Old URL:
https://plan.s.centralcoast.nsw.gov.au/Pages/XC.Track/SearchApplication.aspx

Now redirects to:
https://eservices.centralcoast.nsw.gov.au/ePathway/Production/Web/Default.aspx

This commit removes Gosford from the multiple_icon scraper. However, Gosford needs to be added in the multiple_epathway scraper.

Issue: [#417](https://github.com/planningalerts-scrapers/issues/issues/417)